### PR TITLE
DF-4040 Added URL escaping to GetAppByName func to prevent issue

### DIFF
--- a/pkg/components/insightappsec/client.go
+++ b/pkg/components/insightappsec/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/rapid7/strategic-integrations/appsec/rapid7-insightappsec-threadfix/pkg/shared"
 	log "github.com/sirupsen/logrus"
 )
@@ -12,6 +13,8 @@ type API struct {
 	Config    InsightAppSecConfiguration
 	APIClient shared.APIClient
 }
+
+const UserAgent = "r7:insightappsec-threadfix-extension-1.0.1"
 
 func (ias *API) DoSearch(searchType string, query string, index int, size int, sort string) []byte {
 	var search = SearchParameters{Type: searchType, Query: query}
@@ -218,6 +221,7 @@ func (ias *API) FormatUrl(url Url) string {
 func (ias *API) FormatHeader() map[string]string {
 	var header = make(map[string]string)
 	header["x-api-key"] = ias.Config.APIKey
+	header["User-Agent"] = UserAgent
 
 	return header
 }

--- a/pkg/components/insightappsec/client.go
+++ b/pkg/components/insightappsec/client.go
@@ -14,8 +14,6 @@ type API struct {
 	APIClient shared.APIClient
 }
 
-const UserAgent = "r7:insightappsec-threadfix-extension-1.0.1"
-
 func (ias *API) DoSearch(searchType string, query string, index int, size int, sort string) []byte {
 	var search = SearchParameters{Type: searchType, Query: query}
 	var header = ias.FormatHeader()
@@ -221,7 +219,6 @@ func (ias *API) FormatUrl(url Url) string {
 func (ias *API) FormatHeader() map[string]string {
 	var header = make(map[string]string)
 	header["x-api-key"] = ias.Config.APIKey
-	header["User-Agent"] = UserAgent
 
 	return header
 }

--- a/pkg/components/threadfix/client.go
+++ b/pkg/components/threadfix/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+
 	"github.com/rapid7/strategic-integrations/appsec/rapid7-insightappsec-threadfix/pkg/shared"
 	"github.com/rapid7/strategic-integrations/appsec/rapid7-insightappsec-threadfix/pkg/shared/logging"
 	log "github.com/sirupsen/logrus"
@@ -67,7 +69,7 @@ func (tf *API) ListScans(appId int) ([]ScanMetadata, error) {
 }
 
 func (tf *API) GetAppByName(teamName string, appName string) (Application, error) {
-	var endpoint = fmt.Sprintf("rest/applications/%s/lookup?name=%s", teamName, appName)
+	var endpoint = fmt.Sprintf("rest/applications/%s/lookup?name=%s", teamName, url.QueryEscape(appName))
 	var header = tf.FormatHeader()
 	var url = tf.FormatUrl(endpoint)
 	var app Application


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
There was an issue where TF Applications with spaces in the name could not be found by this query due to the lack of escaping, so QueryEscape was added


### Motivation and Context
https://issues.corp.rapid7.com/browse/DF-4040

